### PR TITLE
chore: refactor to increase testability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -372,6 +372,7 @@ version = "0.1.0"
 dependencies = [
  "avro-rs",
  "futures",
+ "lazy_static",
  "oxigraph",
  "rdkafka",
  "schema_registry_converter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 avro-rs = "0.13.0"
 futures = "0.3.21"
+lazy_static = "1.4.0"
 oxigraph = "0.3.2"
 rdkafka = "0.28.0"
 schema_registry_converter = { version = "2.1.0", features = ["avro", "futures", "rustls_tls"], default-features=false }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 test:
 	docker-compose up -d
 	cargo test -- --test-threads 1
-	docker-compose down
+	docker-compose down -v

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -63,6 +63,7 @@ services:
     healthcheck:
       test: [ "CMD", "curl", "-f", "http://localhost:8081" ]
       interval: 3s
+      retries: 10
 
   # Registers schemas once schema-registry is up.
   schema-registrer:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -75,14 +75,3 @@ services:
     depends_on:
       schema-registry:
         condition: service_healthy
-
-  fdk-mqa-node-mapper:
-    build: .
-    environment:
-      - SCHEMA_REGISTRY_URL=http://schema-registry:8081
-      - BROKER_URL=kafka:29092
-    depends_on:
-      schema-registry:
-        condition: service_healthy
-      kafka:
-        condition: service_healthy

--- a/src/bin/fdk-mqa-node-namer.rs
+++ b/src/bin/fdk-mqa-node-namer.rs
@@ -1,19 +1,18 @@
 extern crate fdk_mqa_node_namer;
 
-use std::{env, time::Duration};
+use std::time::Duration;
 
 use futures::stream::{FuturesUnordered, StreamExt};
 use schema_registry_converter::async_impl::schema_registry::SrSettings;
 
-use fdk_mqa_node_namer::{kafka, schemas::setup_schemas};
+use fdk_mqa_node_namer::{
+    kafka::{self, SCHEMA_REGISTRY},
+    schemas::setup_schemas,
+};
 
 #[tokio::main]
 async fn main() {
-    let schema_registry =
-        env::var("SCHEMA_REGISTRY_URL").unwrap_or("http://localhost:8081".to_string());
-    let broker = env::var("BROKER_URL").unwrap_or("localhost:9092".to_string());
-
-    let sr_settings = SrSettings::new_builder(schema_registry)
+    let sr_settings = SrSettings::new_builder(SCHEMA_REGISTRY.clone())
         .set_timeout(Duration::from_secs(5))
         .build()
         .unwrap();
@@ -21,15 +20,7 @@ async fn main() {
     setup_schemas(&sr_settings).await.unwrap();
 
     (0..4)
-        .map(|_| {
-            tokio::spawn(kafka::run_async_processor(
-                broker.clone(),
-                "fdk-mqa-node-namer".to_string(),
-                "dataset-events".to_string(),
-                "mqa-dataset-events".to_string(),
-                sr_settings.clone(),
-            ))
-        })
+        .map(|_| tokio::spawn(kafka::run_async_processor(sr_settings.clone())))
         .collect::<FuturesUnordered<_>>()
         .for_each(|result| async {
             match result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-mod error;
+pub mod error;
 mod graph;
 pub mod kafka;
 pub mod schemas;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -109,7 +109,7 @@ async fn assert_transformation(input: &str, expected: &str) {
         .await;
 
     // Wait for node-namer to process message and assert result is ok
-    assert!(processor.await.is_ok());
+    processor.await.unwrap();
 
     // Consume message produced by node-namer
     let message = consumer.recv().await;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,9 @@
 use avro_rs::from_value;
-use fdk_mqa_node_namer::schemas::{DatasetEvent, DatasetEventType};
-use kafka_utils::{TestConsumer, TestProducer};
+use fdk_mqa_node_namer::{
+    kafka::{INPUT_TOPIC, OUTPUT_TOPIC},
+    schemas::{DatasetEvent, DatasetEventType},
+};
+use kafka_utils::{process_single_message, TestConsumer, TestProducer};
 use utils::sorted_lines;
 
 mod kafka_utils;
@@ -87,8 +90,6 @@ async fn real_world_example() {
 }
 
 async fn assert_transformation(input: &str, expected: &str) {
-    let mut consumer = TestConsumer::new("mqa-dataset-events");
-
     let input_message = DatasetEvent {
         event_type: DatasetEventType::DatasetHarvested,
         timestamp: 1647698566000,
@@ -96,11 +97,21 @@ async fn assert_transformation(input: &str, expected: &str) {
         graph: input.to_string(),
     };
 
-    TestProducer::new("dataset-events")
+    // Start node-namer
+    let processor = process_single_message();
+    // Create consumer on node-namer output topic, and read all current messages
+    let mut consumer = TestConsumer::new(&OUTPUT_TOPIC);
+    consumer.read_all().await;
+    // Produce message to node-namer input topic
+    TestProducer::new(&INPUT_TOPIC)
         .produce(&input_message, "no.fdk.dataset.DatasetEvent")
         .await;
 
-    let message = consumer.consume().await;
+    // Wait for node-namer to process message and assert result is ok
+    assert!(processor.await.is_ok());
+
+    // Consume message produced by node-namer
+    let message = consumer.recv().await;
     let event = from_value::<DatasetEvent>(&message).unwrap();
 
     assert_eq!(sorted_lines(&event.graph), sorted_lines(expected));

--- a/tests/kafka_utils.rs
+++ b/tests/kafka_utils.rs
@@ -1,6 +1,10 @@
 use std::time::Duration;
 
 use avro_rs::types::Value;
+use fdk_mqa_node_namer::{
+    error::Error,
+    kafka::{create_consumer, create_producer, handle_message, BROKERS},
+};
 use futures::StreamExt;
 use rdkafka::{
     consumer::{Consumer, StreamConsumer},
@@ -15,6 +19,18 @@ use schema_registry_converter::{
     schema_registry_common::SubjectNameStrategy,
 };
 use serde::Serialize;
+
+pub async fn process_single_message() -> Result<(), Error> {
+    let producer = create_producer().unwrap();
+    let consumer = create_consumer().unwrap();
+    let message = tokio::time::timeout(Duration::from_millis(3000), consumer.recv())
+        .await
+        .unwrap()
+        .unwrap()
+        .detach();
+
+    handle_message(message, sr_settings(), producer).await
+}
 
 pub fn sr_settings() -> SrSettings {
     let schema_registry = "http://localhost:8081";
@@ -32,10 +48,8 @@ pub struct TestProducer<'a> {
 
 impl TestProducer<'_> {
     pub fn new(topic: &'static str) -> Self {
-        let bootstrap_servers = "localhost:9092";
         let producer = ClientConfig::new()
-            .set("bootstrap.servers", bootstrap_servers)
-            .set("message.timeout.ms", "5000")
+            .set("bootstrap.servers", BROKERS.clone())
             .create::<FutureProducer>()
             .expect("Failed to create Kafka FutureProducer");
 
@@ -71,16 +85,9 @@ pub struct TestConsumer<'a> {
 
 impl TestConsumer<'_> {
     pub fn new(topic: &'static str) -> Self {
-        let bootstrap_servers = "localhost:9092";
         let consumer = ClientConfig::new()
             .set("group.id", "fdk-mqa-node-namer-test")
-            .set("bootstrap.servers", bootstrap_servers)
-            .set("enable.partition.eof", "false")
-            .set("session.timeout.ms", "6000")
-            .set("enable.auto.commit", "true")
-            .set("api.version.request", "false")
-            .set("security.protocol", "plaintext")
-            .set("debug", "all")
+            .set("bootstrap.servers", BROKERS.clone())
             .create::<StreamConsumer>()
             .expect("Failed to create Kafka StreamConsumer");
 
@@ -92,10 +99,14 @@ impl TestConsumer<'_> {
         Self { consumer, decoder }
     }
 
-    pub async fn consume(&mut self) -> Value {
-        let msg = tokio::time::timeout(Duration::from_secs(10), self.consumer.stream().next())
+    pub async fn read_all(&mut self) {
+        let _ =
+            tokio::time::timeout(Duration::from_millis(100), self.consumer.stream().count()).await;
+    }
+
+    pub async fn recv(&mut self) -> Value {
+        let msg = tokio::time::timeout(Duration::from_millis(3000), self.consumer.recv())
             .await
-            .expect("No messages to consume")
             .unwrap()
             .unwrap()
             .detach();


### PR DESCRIPTION
Mulliggjør å kjøre node-namer i testene, fremfor å ha den bygget og kjørende som et docker image i bakgrunnen. Sparer mye tid, fordi man slipper å bygge hele imaget ved endring.